### PR TITLE
RWA-948 & RWA-822: R2 Post deployment Fts and multiple scenario Support

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/domain/taskmanagement/request/enums/TerminateReason.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/domain/taskmanagement/request/enums/TerminateReason.java
@@ -1,5 +1,5 @@
 package uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.enums;
 
 public enum TerminateReason {
-    COMPLETED, CANCELLED
+    COMPLETED, CANCELLED, DELETED
 }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobService.java
@@ -13,8 +13,6 @@ import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.InitiateT
 import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.TaskAttribute;
 import uk.gov.hmcts.reform.wataskmonitor.utils.ResourceUtility;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -111,14 +109,7 @@ public class InitiationJobService {
     }
 
     private String buildSearchQuery() {
-        return ResourceUtility.getResource(CAMUNDA_TASKS_CFT_TASK_STATE_UNCONFIGURED)
-            .replace("CREATED_BEFORE_PLACEHOLDER", getCreatedBeforeDate());
-    }
-
-    private static String getCreatedBeforeDate() {
-        return ZonedDateTime.now()
-            .minusMinutes(5)
-            .format(DateTimeFormatter.ofPattern(CAMUNDA_DATE_REQUEST_PATTERN));
+        return ResourceUtility.getResource(CAMUNDA_TASKS_CFT_TASK_STATE_UNCONFIGURED);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.enums.TerminateReason.CANCELLED;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.enums.TerminateReason.COMPLETED;
+import static uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.enums.TerminateReason.DELETED;
 import static uk.gov.hmcts.reform.wataskmonitor.services.ResourceEnum.CAMUNDA_HISTORIC_TASKS_PENDING_TERMINATION;
 
 @Slf4j
@@ -43,8 +44,13 @@ public class TerminationJobService {
             .filter(t -> t.getDeleteReason().equals("cancelled"))
             .collect(Collectors.toList());
 
+        List<HistoricCamundaTask> deletedTasks = tasks.stream()
+            .filter(t -> t.getDeleteReason().equals("deleted"))
+            .collect(Collectors.toList());
+
         terminateAllTasksWithReason(serviceAuthorizationToken, completedTasks, COMPLETED);
         terminateAllTasksWithReason(serviceAuthorizationToken, cancelledTasks, CANCELLED);
+        terminateAllTasksWithReason(serviceAuthorizationToken, deletedTasks, DELETED);
     }
 
     private List<HistoricCamundaTask> getTasksPendingTermination(String serviceToken) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,6 +38,9 @@ spring:
 camunda:
   url: ${CAMUNDA_URL:http://camunda-local-bpm/engine-rest}
 
+task-configuration:
+  url: ${TASK_CONFIGURATION_SERVICE_URL:http://localhost:8091}
+
 task-management:
   url: ${TASK_MANAGEMENT_SERVICE_URL:http://localhost:8087}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,9 +38,6 @@ spring:
 camunda:
   url: ${CAMUNDA_URL:http://camunda-local-bpm/engine-rest}
 
-task-configuration:
-  url: ${TASK_CONFIGURATION_SERVICE_URL:http://localhost:8091}
-
 task-management:
   url: ${TASK_MANAGEMENT_SERVICE_URL:http://localhost:8087}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,7 +60,7 @@ idam:
     secret: ${S2S_SECRET_TASK_MONITOR:AAAAAAAAAAAAAAAA}
     name: wa_task_monitor
   s2s-authorised:
-    services: ${WA_S2S_AUTHORIZED_SERVICES:wa_task_monitor}
+    services: ${WA_S2S_AUTHORIZED_SERVICES:wa_task_monitor,wa_task_management_api}
   system:
     username: ${WA_SYSTEM_USERNAME:some_user@hmcts.net}
     password: ${WA_SYSTEM_PASSWORD:password}

--- a/src/main/resources/camunda/camunda-historic-task-pending-termination-query.json
+++ b/src/main/resources/camunda/camunda-historic-task-pending-termination-query.json
@@ -6,5 +6,6 @@
       "value": "pendingTermination"
     }
   ],
+  "taskDefinitionKey": "processTask",
   "processDefinitionKey": "wa-task-initiation-ia-asylum"
 }

--- a/src/main/resources/camunda/camunda-search-cftTaskState-unconfigured.json
+++ b/src/main/resources/camunda/camunda-search-cftTaskState-unconfigured.json
@@ -10,7 +10,6 @@
       ]
     }
   ],
-  "createdBefore": "CREATED_BEFORE_PLACEHOLDER",
   "taskDefinitionKey": "processTask",
   "processDefinitionKey": "wa-task-initiation-ia-asylum"
 }

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobTest.java
@@ -25,7 +25,7 @@ class TerminationJobTest extends UnitBaseTest {
         "CONFIGURATION, false",
         "AD_HOC_DELETE_PROCESS_INSTANCES, false"
     })
-    void canRun(JobName jobName, boolean expectedResult) {
+    void can_run(JobName jobName, boolean expectedResult) {
         assertThat(terminationJob.canRun(jobName)).isEqualTo(expectedResult);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Removes before date for initiation request to better support immediate creation of tasks in post-deployment-ft-tests

whitelisted wa-task-management-api as the post-deployment tests makes requests as task management and now needs to manually trigger the jobs
constraint termination job to activity id process task


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
