### PR TITLE
RWA-1054: Default taskType to taskId when taskType is null to allow migration to R2

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmonitor/MonitorTaskJobControllerForInitiationJobTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmonitor/MonitorTaskJobControllerForInitiationJobTest.java
@@ -26,7 +26,7 @@ import static uk.gov.hmcts.reform.wataskmonitor.controllers.MonitorTaskJobContro
 @SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.LawOfDemeter"})
 public class MonitorTaskJobControllerForInitiationJobTest extends SpringBootFunctionalBaseTest {
 
-    private List<String> caseIds = new ArrayList<>();
+    private List<String> caseIds;
 
     private Headers authenticationHeaders;
 
@@ -34,6 +34,7 @@ public class MonitorTaskJobControllerForInitiationJobTest extends SpringBootFunc
     public void setUp() {
         authenticationHeaders = authorizationHeadersProvider
             .getTribunalCaseworkerAAuthorization("wa-mvp-ft-test-");
+        caseIds = new ArrayList<>();
     }
 
     @After

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapper.java
@@ -27,6 +27,7 @@ import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVari
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVariableDefinition.LOCATION_NAME;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVariableDefinition.REGION;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVariableDefinition.SECURITY_CLASSIFICATION;
+import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVariableDefinition.TASK_ID;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVariableDefinition.TASK_STATE;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVariableDefinition.TASK_SYSTEM;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.enums.CamundaVariableDefinition.TASK_TYPE;
@@ -54,6 +55,21 @@ public class InitiationTaskAttributesMapper {
         String description = camundaTask.getDescription();
         // Local Variables
         String type = getVariableValue(variables.get(TASK_TYPE.value()), String.class, null);
+
+        if (type == null) {
+            String taskId = getVariableValue(variables.get(TASK_ID.value()), String.class, null);
+            /*
+             * In some R1 tasks the taskType does not exist which will cause it to fail when attempting to initate
+             * a task to allow for R1 to R2 migration we attempt to use the taskId instead who's value should be
+             * the same as taskType.
+             */
+            log.info(
+                "Task '{}' did not have a 'taskType' defaulting to 'taskId' with value '{}'",
+                camundaTask.getId(), taskId
+            );
+            type = taskId;
+        }
+
         CFTTaskState taskState = extractTaskState(variables);
         String executionTypeName = getVariableValue(variables.get(EXECUTION_TYPE.value()),
             String.class,
@@ -61,7 +77,7 @@ public class InitiationTaskAttributesMapper {
         String securityClassification = getVariableValue(variables.get(SECURITY_CLASSIFICATION.value()),
             String.class,
             null);
-        String taskTitle = getVariableValue(variables.get(TITLE.value()), String.class,null);
+        String taskTitle = getVariableValue(variables.get(TITLE.value()), String.class, null);
 
         boolean autoAssigned = getVariableValue(variables.get(AUTO_ASSIGNED.value()), Boolean.class, false);
         String taskSystem = getVariableValue(variables.get(TASK_SYSTEM.value()), String.class, null);

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapperTest.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.CamundaTime.CAMUNDA_DATA_TIME_FORMATTER;
 import static uk.gov.hmcts.reform.wataskmonitor.services.jobs.initiation.helpers.InitiationHelpers.createMockCamundaVariables;
 import static uk.gov.hmcts.reform.wataskmonitor.services.jobs.initiation.helpers.InitiationHelpers.createMockedCamundaTask;
@@ -33,6 +32,11 @@ class InitiationTaskAttributesMapperTest extends UnitBaseTest {
 
     @InjectMocks
     InitiationTaskAttributesMapper initiationTaskAttributesMapper;
+
+    @BeforeEach
+    void setUp() {
+        initiationTaskAttributesMapper = new InitiationTaskAttributesMapper(new ObjectMapper());
+    }
 
     public static Stream<Arguments> scenarioProvider() {
         Map<String, CamundaVariable> camundaVariables = createMockCamundaVariables();
@@ -45,11 +49,6 @@ class InitiationTaskAttributesMapperTest extends UnitBaseTest {
             Arguments.of("all vars are present", camundaVariables),
             Arguments.of("autoAssigned is not present", camundaVariablesWithNoAutoAssigned)
         );
-    }
-
-    @BeforeEach
-    void setUp() {
-        initiationTaskAttributesMapper = new InitiationTaskAttributesMapper(new ObjectMapper());
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.wataskmonitor.services.jobs.initiation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -15,11 +16,13 @@ import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.enums.CFT
 import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.enums.TaskAttributeDefinition;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.reform.wataskmonitor.domain.camunda.CamundaTime.CAMUNDA_DATA_TIME_FORMATTER;
 import static uk.gov.hmcts.reform.wataskmonitor.services.jobs.initiation.helpers.InitiationHelpers.createMockCamundaVariables;
@@ -31,21 +34,22 @@ class InitiationTaskAttributesMapperTest extends UnitBaseTest {
     @InjectMocks
     InitiationTaskAttributesMapper initiationTaskAttributesMapper;
 
-    @BeforeEach
-    void setUp() {
-        initiationTaskAttributesMapper = new InitiationTaskAttributesMapper(new ObjectMapper());
-    }
-
     public static Stream<Arguments> scenarioProvider() {
         Map<String, CamundaVariable> camundaVariables = createMockCamundaVariables();
 
         Map<String, CamundaVariable> camundaVariablesWithNoAutoAssigned = createMockCamundaVariables();
         camundaVariablesWithNoAutoAssigned.remove("autoAssigned");
 
+
         return Stream.of(
             Arguments.of("all vars are present", camundaVariables),
             Arguments.of("autoAssigned is not present", camundaVariablesWithNoAutoAssigned)
         );
+    }
+
+    @BeforeEach
+    void setUp() {
+        initiationTaskAttributesMapper = new InitiationTaskAttributesMapper(new ObjectMapper());
     }
 
     @ParameterizedTest
@@ -60,10 +64,43 @@ class InitiationTaskAttributesMapperTest extends UnitBaseTest {
         List<TaskAttribute> actual = initiationTaskAttributesMapper.mapTaskAttributes(camundaTask, variables);
         List<TaskAttribute> expected = getExpectedTaskAttributes(createdDate, dueDate);
 
-        assertEquals(expected, actual);
+        assertThat(actual).hasSameElementsAs(expected);
+    }
+
+    @Test
+    void should_map_taskId_to_taskType_when_taskType_is_null() {
+        Map<String, CamundaVariable> camundaVariablesWithNoTaskType = createMockCamundaVariables();
+        camundaVariablesWithNoTaskType.put("taskId", new CamundaVariable("someTaskId", "String"));
+        camundaVariablesWithNoTaskType.remove("taskType");
+        ZonedDateTime createdDate = ZonedDateTime.now();
+        ZonedDateTime dueDate = createdDate.plusDays(1);
+
+        CamundaTask camundaTask = createMockedCamundaTask(createdDate, dueDate);
+
+        List<TaskAttribute> actual = initiationTaskAttributesMapper.mapTaskAttributes(camundaTask, camundaVariablesWithNoTaskType);
+        List<TaskAttribute> expected = getExpectedTaskAttributes(createdDate, dueDate, "someTaskId");
+        assertThat(actual).hasSameElementsAs(expected);
+    }
+
+
+    private List<TaskAttribute> getExpectedTaskAttributes(ZonedDateTime createdDate,
+                                                          ZonedDateTime dueDate,
+                                                          String customTaskType) {
+
+        List<TaskAttribute> attributes = new ArrayList<>(getExpectedBaseTaskAttributes(createdDate, dueDate));
+        attributes.add(new TaskAttribute(TaskAttributeDefinition.TASK_TYPE, customTaskType));
+
+        return attributes;
     }
 
     private List<TaskAttribute> getExpectedTaskAttributes(ZonedDateTime createdDate, ZonedDateTime dueDate) {
+        List<TaskAttribute> attributes = new ArrayList<>(getExpectedBaseTaskAttributes(createdDate, dueDate));
+        attributes.add(new TaskAttribute(TaskAttributeDefinition.TASK_TYPE, "someTaskType"));
+
+        return attributes;
+    }
+
+    private List<TaskAttribute> getExpectedBaseTaskAttributes(ZonedDateTime createdDate, ZonedDateTime dueDate) {
 
         return asList(
             new TaskAttribute(TaskAttributeDefinition.TASK_ASSIGNEE, "someAssignee"),
@@ -87,7 +124,6 @@ class InitiationTaskAttributesMapperTest extends UnitBaseTest {
             new TaskAttribute(TaskAttributeDefinition.TASK_STATE, CFTTaskState.UNCONFIGURED),
             new TaskAttribute(TaskAttributeDefinition.TASK_SYSTEM, "someTaskSystem"),
             new TaskAttribute(TaskAttributeDefinition.TASK_TITLE, "someTitle"),
-            new TaskAttribute(TaskAttributeDefinition.TASK_TYPE, "someTaskType"),
             //Unmapped
             new TaskAttribute(TaskAttributeDefinition.TASK_ASSIGNMENT_EXPIRY, null),
             new TaskAttribute(TaskAttributeDefinition.TASK_BUSINESS_CONTEXT, null),

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationTaskAttributesMapperTest.java
@@ -33,22 +33,21 @@ class InitiationTaskAttributesMapperTest extends UnitBaseTest {
     @InjectMocks
     InitiationTaskAttributesMapper initiationTaskAttributesMapper;
 
-    @BeforeEach
-    void setUp() {
-        initiationTaskAttributesMapper = new InitiationTaskAttributesMapper(new ObjectMapper());
-    }
-
     public static Stream<Arguments> scenarioProvider() {
         Map<String, CamundaVariable> camundaVariables = createMockCamundaVariables();
 
         Map<String, CamundaVariable> camundaVariablesWithNoAutoAssigned = createMockCamundaVariables();
         camundaVariablesWithNoAutoAssigned.remove("autoAssigned");
 
-
         return Stream.of(
             Arguments.of("all vars are present", camundaVariables),
             Arguments.of("autoAssigned is not present", camundaVariablesWithNoAutoAssigned)
         );
+    }
+
+    @BeforeEach
+    void setUp() {
+        initiationTaskAttributesMapper = new InitiationTaskAttributesMapper(new ObjectMapper());
     }
 
     @ParameterizedTest
@@ -76,7 +75,10 @@ class InitiationTaskAttributesMapperTest extends UnitBaseTest {
 
         CamundaTask camundaTask = createMockedCamundaTask(createdDate, dueDate);
 
-        List<TaskAttribute> actual = initiationTaskAttributesMapper.mapTaskAttributes(camundaTask, camundaVariablesWithNoTaskType);
+        List<TaskAttribute> actual = initiationTaskAttributesMapper.mapTaskAttributes(
+            camundaTask,
+            camundaVariablesWithNoTaskType
+        );
         List<TaskAttribute> expected = getExpectedTaskAttributes(createdDate, dueDate, "someTaskId");
         assertThat(actual).hasSameElementsAs(expected);
     }


### PR DESCRIPTION
### Change description ###

Default taskType to taskId when taskType is null to allow migration to R2

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
