### PR TITLE
Reduce the number of max tasks retrieved at once to 100 from 1000 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/clients/camunda/CamundaClientMock.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/clients/camunda/CamundaClientMock.java
@@ -19,7 +19,7 @@ public final class CamundaClientMock {
 
     public static void setupPostTaskCamundaResponseMock(WireMockServer mockServer, String expectedResponse)
         throws IOException {
-        mockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/task?firstResult=0&maxResults=1000"))
+        mockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/task?firstResult=0&maxResults=100"))
             .withHeader(SERVICE_AUTHORIZATION, containing("Bearer"))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.OK_200)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/clients/camunda/CamundaClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/clients/camunda/CamundaClientTest.java
@@ -46,7 +46,7 @@ class CamundaClientTest {
         List<CamundaTask> camundaTasks = camundaClient.getTasks(
             "some service Bearer token",
             "0",
-            "1000",
+            "100",
             ""
         );
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/controllers/MonitorTaskJobControllerForConfigurationJobTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/controllers/MonitorTaskJobControllerForConfigurationJobTest.java
@@ -58,7 +58,7 @@ class MonitorTaskJobControllerForConfigurationJobTest extends SpringBootIntegrat
         verify(camundaClient).getTasks(
             eq(SERVICE_TOKEN),
             eq("0"),
-            eq("10"),
+            eq("100"),
             argThat(new CamundaQueryParametersMatcher(TestUtility.getExpectedRequestForUnconfiguredTasks()))
         );
         verify(taskConfigurationClient).configureTask(eq(SERVICE_TOKEN), eq(CAMUNDA_TASK_ID));
@@ -70,7 +70,7 @@ class MonitorTaskJobControllerForConfigurationJobTest extends SpringBootIntegrat
         when(camundaClient.getTasks(
             eq(SERVICE_TOKEN),
             eq("0"),
-            eq("10"),
+            eq("100"),
             argThat(new CamundaQueryParametersMatcher(TestUtility.getExpectedRequestForUnconfiguredTasks()))
         )).thenReturn(List.of(new CamundaTask(
             CAMUNDA_TASK_ID,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/controllers/MonitorTaskJobControllerForInitiationJobTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/controllers/MonitorTaskJobControllerForInitiationJobTest.java
@@ -62,7 +62,7 @@ class MonitorTaskJobControllerForInitiationJobTest extends SpringBootIntegration
         verify(camundaClient).getTasks(
             eq(SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             any()
         );
 
@@ -123,7 +123,7 @@ class MonitorTaskJobControllerForInitiationJobTest extends SpringBootIntegration
         when(camundaClient.getTasks(
             eq(SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             any()
         )).thenReturn(
             List.of(camundaTask)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/controllers/MonitorTaskJobControllerForTerminationJobTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskmonitor/controllers/MonitorTaskJobControllerForTerminationJobTest.java
@@ -58,7 +58,7 @@ class MonitorTaskJobControllerForTerminationJobTest extends SpringBootIntegratio
         verify(camundaClient).getTasksFromHistory(
             eq(SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             any()
         );
 
@@ -86,7 +86,7 @@ class MonitorTaskJobControllerForTerminationJobTest extends SpringBootIntegratio
         when(camundaClient.getTasksFromHistory(
             eq(SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             any()
         )).thenReturn(
             List.of(

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/clients/CamundaClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/clients/CamundaClient.java
@@ -33,7 +33,7 @@ public interface CamundaClient {
     List<CamundaTask> getTasks(
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
         @RequestParam(value = "firstResult", required = false, defaultValue = "0") String firstResult,
-        @RequestParam(value = "maxResults", required = false, defaultValue = "1000") String maxResults,
+        @RequestParam(value = "maxResults", required = false, defaultValue = "100") String maxResults,
         @RequestBody String body
     );
 
@@ -66,7 +66,7 @@ public interface CamundaClient {
     List<HistoricCamundaTask> getTasksFromHistory(
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
         @RequestParam(value = "firstResult", required = false, defaultValue = "0") String firstResult,
-        @RequestParam(value = "maxResults", required = false, defaultValue = "1000") String maxResults,
+        @RequestParam(value = "maxResults", required = false, defaultValue = "100") String maxResults,
         @RequestBody String body
     );
 

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/config/job/InitiationJobConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/config/job/InitiationJobConfig.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.wataskmonitor.config.job;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "job.initiation")
+@Getter
+@Setter
+public class InitiationJobConfig {
+    String camundaMaxResults;
+}

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/config/job/TerminationJobConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/config/job/TerminationJobConfig.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.wataskmonitor.config.job;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "job.termination")
+@Getter
+@Setter
+public class TerminationJobConfig {
+    String camundaMaxResults;
+}

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobService.java
@@ -45,7 +45,7 @@ public class InitiationJobService {
         List<CamundaTask> camundaTasks = camundaClient.getTasks(
             serviceToken,
             "0",
-            "1000",
+            "100",
             buildSearchQuery()
         );
         log.info("{} task(s) retrieved successfully.", camundaTasks.size());

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.wataskmonitor.clients.CamundaClient;
 import uk.gov.hmcts.reform.wataskmonitor.clients.TaskManagementClient;
+import uk.gov.hmcts.reform.wataskmonitor.config.job.InitiationJobConfig;
 import uk.gov.hmcts.reform.wataskmonitor.domain.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskmonitor.domain.camunda.CamundaVariable;
 import uk.gov.hmcts.reform.wataskmonitor.domain.jobs.GenericJobOutcome;
@@ -30,14 +31,17 @@ public class InitiationJobService {
     private final CamundaClient camundaClient;
     private final TaskManagementClient taskManagementClient;
     private final InitiationTaskAttributesMapper initiationTaskAttributesMapper;
+    private final InitiationJobConfig initiationJobConfig;
 
     @Autowired
     public InitiationJobService(CamundaClient camundaClient,
                                 TaskManagementClient taskManagementClient,
-                                InitiationTaskAttributesMapper initiationTaskAttributesMapper) {
+                                InitiationTaskAttributesMapper initiationTaskAttributesMapper,
+                                InitiationJobConfig initiationJobConfig) {
         this.camundaClient = camundaClient;
         this.taskManagementClient = taskManagementClient;
         this.initiationTaskAttributesMapper = initiationTaskAttributesMapper;
+        this.initiationJobConfig = initiationJobConfig;
     }
 
     public List<CamundaTask> getUnConfiguredTasks(String serviceToken) {
@@ -45,7 +49,7 @@ public class InitiationJobService {
         List<CamundaTask> camundaTasks = camundaClient.getTasks(
             serviceToken,
             "0",
-            "100",
+            initiationJobConfig.getCamundaMaxResults(),
             buildSearchQuery()
         );
         log.info("{} task(s) retrieved successfully.", camundaTasks.size());

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
@@ -39,7 +39,7 @@ public class TerminationJobService {
         List<HistoricCamundaTask> camundaTasks = camundaClient.getTasksFromHistory(
             serviceToken,
             "0",
-            "1000",
+            "100",
             buildHistoricTasksPendingTerminationRequest()
         );
         log.info("{} task(s) retrieved successfully.", camundaTasks.size());

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.wataskmonitor.clients.CamundaClient;
 import uk.gov.hmcts.reform.wataskmonitor.clients.TaskManagementClient;
-import uk.gov.hmcts.reform.wataskmonitor.config.job.InitiationJobConfig;
 import uk.gov.hmcts.reform.wataskmonitor.config.job.TerminationJobConfig;
 import uk.gov.hmcts.reform.wataskmonitor.domain.camunda.HistoricCamundaTask;
 import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.TerminateTaskRequest;

--- a/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobService.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.wataskmonitor.clients.CamundaClient;
 import uk.gov.hmcts.reform.wataskmonitor.clients.TaskManagementClient;
+import uk.gov.hmcts.reform.wataskmonitor.config.job.InitiationJobConfig;
+import uk.gov.hmcts.reform.wataskmonitor.config.job.TerminationJobConfig;
 import uk.gov.hmcts.reform.wataskmonitor.domain.camunda.HistoricCamundaTask;
 import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.TerminateTaskRequest;
 import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.options.TerminateInfo;
@@ -21,12 +23,16 @@ public class TerminationJobService {
 
     private final CamundaClient camundaClient;
     private final TaskManagementClient taskManagementClient;
+    private final TerminationJobConfig terminationJobConfig;
 
 
     @Autowired
-    public TerminationJobService(CamundaClient camundaClient, TaskManagementClient taskManagementClient) {
+    public TerminationJobService(CamundaClient camundaClient,
+                                 TaskManagementClient taskManagementClient,
+                                 TerminationJobConfig terminationJobConfig) {
         this.camundaClient = camundaClient;
         this.taskManagementClient = taskManagementClient;
+        this.terminationJobConfig = terminationJobConfig;
     }
 
     public void terminateTasks(String serviceAuthorizationToken) {
@@ -39,7 +45,7 @@ public class TerminationJobService {
         List<HistoricCamundaTask> camundaTasks = camundaClient.getTasksFromHistory(
             serviceToken,
             "0",
-            "100",
+            terminationJobConfig.getCamundaMaxResults(),
             buildHistoricTasksPendingTerminationRequest()
         );
         log.info("{} task(s) retrieved successfully.", camundaTasks.size());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -91,7 +91,11 @@ feign:
 
 job:
   configuration:
-    camunda-max-results: ${CONFIGURATION_CAMUNDA_MAX_RESULTS:10}
+    camunda-max-results: ${CONFIGURATION_CAMUNDA_MAX_RESULTS:100}
+  initiation:
+    camunda-max-results: ${INITIATION_CAMUNDA_MAX_RESULTS:100}
+  termination:
+    camunda-max-results: ${TERMINATION_CAMUNDA_MAX_RESULTS:100}
 
 role-assignment-service:
   url: ${ROLE_ASSIGNMENT_URL:http://role-assignment}

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/config/job/InitiationJobConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/config/job/InitiationJobConfigTest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.wataskmonitor.config.job;
+
+import org.junit.jupiter.api.Test;
+import pl.pojo.tester.api.assertion.Method;
+
+import static pl.pojo.tester.api.assertion.Assertions.assertPojoMethodsFor;
+
+class InitiationJobConfigTest {
+    @Test
+    void isWellImplemented() {
+        final Class<?> classUnderTest = InitiationJobConfig.class;
+        assertPojoMethodsFor(classUnderTest)
+            .testing(Method.GETTER)
+            .testing(Method.SETTER)
+            .testing(Method.CONSTRUCTOR)
+            .areWellImplemented();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/config/job/TerminationJobConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/config/job/TerminationJobConfigTest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.wataskmonitor.config.job;
+
+import org.junit.jupiter.api.Test;
+import pl.pojo.tester.api.assertion.Method;
+
+import static pl.pojo.tester.api.assertion.Assertions.assertPojoMethodsFor;
+
+class TerminationJobConfigTest {
+    @Test
+    void isWellImplemented() {
+        final Class<?> classUnderTest = TerminationJobConfig.class;
+        assertPojoMethodsFor(classUnderTest)
+            .testing(Method.GETTER)
+            .testing(Method.SETTER)
+            .testing(Method.CONSTRUCTOR)
+            .areWellImplemented();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobServiceTest.java
@@ -13,6 +13,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import uk.gov.hmcts.reform.wataskmonitor.UnitBaseTest;
 import uk.gov.hmcts.reform.wataskmonitor.clients.CamundaClient;
 import uk.gov.hmcts.reform.wataskmonitor.clients.TaskManagementClient;
+import uk.gov.hmcts.reform.wataskmonitor.config.job.InitiationJobConfig;
 import uk.gov.hmcts.reform.wataskmonitor.domain.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskmonitor.domain.camunda.CamundaVariable;
 import uk.gov.hmcts.reform.wataskmonitor.domain.jobs.GenericJobOutcome;
@@ -40,19 +41,23 @@ class InitiationJobServiceTest extends UnitBaseTest {
     private CamundaClient camundaClient;
     @Mock
     private TaskManagementClient taskManagementClient;
-    private InitiationTaskAttributesMapper initiationTaskAttributesMapper;
+    @Mock
+    private InitiationJobConfig initiationJobConfig;
     private InitiationJobService initiationJobService;
     @Captor
     private ArgumentCaptor<String> actualQueryParametersCaptor;
 
     @BeforeEach
     void setUp() {
-        initiationTaskAttributesMapper = new InitiationTaskAttributesMapper(new ObjectMapper());
+        InitiationTaskAttributesMapper initiationTaskAttributesMapper =
+            new InitiationTaskAttributesMapper(new ObjectMapper());
         initiationJobService = new InitiationJobService(
             camundaClient,
             taskManagementClient,
-            initiationTaskAttributesMapper
+            initiationTaskAttributesMapper,
+            initiationJobConfig
         );
+        when(initiationJobConfig.getCamundaMaxResults()).thenReturn("100");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobServiceTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,7 +58,7 @@ class InitiationJobServiceTest extends UnitBaseTest {
             initiationTaskAttributesMapper,
             initiationJobConfig
         );
-        when(initiationJobConfig.getCamundaMaxResults()).thenReturn("100");
+        lenient().when(initiationJobConfig.getCamundaMaxResults()).thenReturn("100");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/initiation/InitiationJobServiceTest.java
@@ -66,7 +66,7 @@ class InitiationJobServiceTest extends UnitBaseTest {
         when(camundaClient.getTasks(
             eq(SOME_SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             actualQueryParametersCaptor.capture()
         )).thenReturn(tasks);
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobServiceTest.java
@@ -64,7 +64,7 @@ class TerminationJobServiceTest extends UnitBaseTest {
             .getTasksFromHistory(
                 eq(SOME_SERVICE_TOKEN),
                 eq("0"),
-                eq("1000"),
+                eq("100"),
                 any()
             );
 
@@ -94,7 +94,7 @@ class TerminationJobServiceTest extends UnitBaseTest {
         when(camundaClient.getTasksFromHistory(
             eq(SOME_SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             actualQueryParametersCaptor.capture()
         )).thenReturn(expectedCamundaTasks);
 
@@ -107,7 +107,7 @@ class TerminationJobServiceTest extends UnitBaseTest {
         when(camundaClient.getTasksFromHistory(
             eq(SOME_SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             actualQueryParametersCaptor.capture()
         )).thenReturn(Collections.emptyList());
 
@@ -131,7 +131,7 @@ class TerminationJobServiceTest extends UnitBaseTest {
         when(camundaClient.getTasksFromHistory(
             eq(SOME_SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             actualQueryParametersCaptor.capture()
         )).thenReturn(expectedCamundaTasks);
 
@@ -152,7 +152,7 @@ class TerminationJobServiceTest extends UnitBaseTest {
         when(camundaClient.getTasksFromHistory(
             eq(SOME_SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             actualQueryParametersCaptor.capture()
         )).thenReturn(expectedCamundaTasks);
 
@@ -173,7 +173,7 @@ class TerminationJobServiceTest extends UnitBaseTest {
         when(camundaClient.getTasksFromHistory(
             eq(SOME_SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             actualQueryParametersCaptor.capture()
         )).thenReturn(expectedCamundaTasks);
 
@@ -194,7 +194,7 @@ class TerminationJobServiceTest extends UnitBaseTest {
         when(camundaClient.getTasksFromHistory(
             eq(SOME_SERVICE_TOKEN),
             eq("0"),
-            eq("1000"),
+            eq("100"),
             actualQueryParametersCaptor.capture()
         )).thenReturn(expectedCamundaTasks);
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskmonitor/services/jobs/termination/TerminationJobServiceTest.java
@@ -3,16 +3,17 @@ package uk.gov.hmcts.reform.wataskmonitor.services.jobs.termination;
 import feign.FeignException;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import uk.gov.hmcts.reform.wataskmonitor.UnitBaseTest;
 import uk.gov.hmcts.reform.wataskmonitor.clients.CamundaClient;
 import uk.gov.hmcts.reform.wataskmonitor.clients.TaskManagementClient;
+import uk.gov.hmcts.reform.wataskmonitor.config.job.TerminationJobConfig;
 import uk.gov.hmcts.reform.wataskmonitor.domain.camunda.HistoricCamundaTask;
 import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.TerminateTaskRequest;
 import uk.gov.hmcts.reform.wataskmonitor.domain.taskmanagement.request.options.TerminateInfo;
@@ -38,10 +39,22 @@ class TerminationJobServiceTest extends UnitBaseTest {
     @Mock
     private TaskManagementClient taskManagementClient;
 
-    @InjectMocks
     private TerminationJobService terminationJobService;
     @Captor
     private ArgumentCaptor<String> actualQueryParametersCaptor;
+
+    @Mock
+    private TerminationJobConfig terminationJobConfig;
+
+    @BeforeEach
+    void setUp() {
+        terminationJobService = new TerminationJobService(
+            camundaClient,
+            taskManagementClient,
+            terminationJobConfig
+        );
+        when(terminationJobConfig.getCamundaMaxResults()).thenReturn("100");
+    }
 
     @Test
     void should_throw_exception_when_camunda_call_fails() {


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Reduce the number of max tasks retrieved at once to 100 from 1000 to investigate an issue where WA seems to be calling idam too often

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
