### PR TITLE
RWA-1573 - CVE-2022-34305 suppression, tomcat upgrade 9.0.64 and upda…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,8 +333,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.1'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.63'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.64'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.64'
 
   implementation group: 'org.awaitility', name: 'awaitility', version: '4.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -330,8 +330,8 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '3.1.2'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.7.5'
 
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.1'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.2'
 
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.64'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.64'

--- a/charts/wa-task-monitor/Chart.yaml
+++ b/charts/wa-task-monitor/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for wa-task-monitor App
 name: wa-task-monitor
 home: https://github.com/hmcts/wa-task-monitor
-version: 0.0.18
+version: 0.0.19
 maintainers:
   - name: HMCTS wa team
 dependencies:
   - name: java
     version: 3.7.4
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -30,4 +30,8 @@
     <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
     <cve>CVE-2022-34305</cve>
   </suppress>
+  <suppress>
+    <notes>False positive log4j-api-2.17.2.jar and log4j-to-slf4j-2.17.2.jar</notes>
+    <cve>CVE-2022-33915</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -26,4 +26,8 @@
     <notes>false positive</notes>
     <cve>CVE-2022-22978</cve>
   </suppress>
+  <suppress>
+    <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
+    <cve>CVE-2022-34305</cve>
+  </suppress>
 </suppressions>

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskmonitor/SpringBootFunctionalBaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskmonitor/SpringBootFunctionalBaseTest.java
@@ -24,8 +24,8 @@ import uk.gov.hmcts.reform.wataskmonitor.utils.Common;
 
 import java.io.IOException;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategy.LOWER_CAMEL_CASE;
-import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.LOWER_CAMEL_CASE;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE;
 import static net.serenitybdd.rest.SerenityRest.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-1573

### Change description ###

CVE-2022-33915 suppression, CVE-2022-34305 suppression, tomcat upgrade 9.0.64, log4j upgrade 2.17.2 and update SpringBootFunctionalBaseTest due to deprecation class

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
