### PR TITLE
RWA-1751: upgraded snakeyaml due to CVE-2022-25857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,6 +308,9 @@ ext.libraries = [
   ]
 ]
 
+//https://nvd.nist.gov/vuln/detail/CVE-2022-25857
+ext['snakeyaml.version'] = '1.31'
+
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1751


### Change description ###
upgraded snakeyaml due to CVE-2022-25857


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
