### PR TITLE
RWA-1829 - dependency-check - CVE-2022-38752

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.7.0'
+  id 'org.springframework.boot' version '2.7.4'
   id 'org.owasp.dependencycheck' version '7.2.1'
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
@@ -319,8 +319,8 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
-  implementation 'org.springframework.boot:spring-boot-starter-security:2.7.0'
-  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.0'
+  implementation 'org.springframework.boot:spring-boot-starter-security:2.7.4'
+  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.4'
 
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: versions.springFrameworkCloud
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.0'
-  id 'org.owasp.dependencycheck' version '7.1.0.1'
+  id 'org.owasp.dependencycheck' version '7.2.1'
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.0'
@@ -309,7 +309,7 @@ ext.libraries = [
 ]
 
 //https://nvd.nist.gov/vuln/detail/CVE-2022-25857
-ext['snakeyaml.version'] = '1.31'
+ext['snakeyaml.version'] = '1.33'
 
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-1829

### Change description ###

RWA-1829 - dependency-check - upgrade org.owasp.dependencycheck to 7.2.1 and snakeyaml.version to 1.33

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
