### PR TITLE
RWA-2133 Fix CVE problem of task monitor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.5'
-  id 'org.owasp.dependencycheck' version '7.2.1'
+  id 'org.owasp.dependencycheck' version '7.4.4'
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.7.5'
+  id 'org.springframework.boot' version '2.7.7'
   id 'org.owasp.dependencycheck' version '7.4.4'
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
@@ -332,8 +332,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.19.0'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.19.0'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.68'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.68'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.69'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.69'
 
   implementation group: 'org.awaitility', name: 'awaitility', version: '4.1.0'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,4 +46,22 @@
     <notes>False positive (https://nvd.nist.gov/vuln/detail/CVE-2021-37533)</notes>
     <cve>CVE-2021-37533</cve>
   </suppress>
+  <suppress>
+    <notes>
+      org.latencyutils:LatencyUtils:2.0.3 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version than LatencyUtils 2.0.3
+    </notes>
+    <cve>CVE-2021-4277</cve>
+  </suppress>
+  <suppress>
+    <notes>
+      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version then snakeyaml 1.33
+    </notes>
+    <cve>CVE-2022-3064</cve>
+  </suppress>
+  <suppress>
+    <notes>
+      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version then snakeyaml 1.33
+    </notes>
+    <cve>CVE-2021-4235</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -54,13 +54,13 @@
   </suppress>
   <suppress>
     <notes>
-      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version then snakeyaml 1.33
+      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version than snakeyaml 1.33
     </notes>
     <cve>CVE-2022-3064</cve>
   </suppress>
   <suppress>
     <notes>
-      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version then snakeyaml 1.33
+      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version than snakeyaml 1.33
     </notes>
     <cve>CVE-2021-4235</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-2133


### Change description ###
-upgrade the dependency check version
-suppress the CVE-2021-4277 since org.latencyutils:LatencyUtils:2.0.3 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version than LatencyUtils 2.0.3 
-suppress the CVE-2022-3064 and CVE-2021-4235 since org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version than snakeyaml 1.33

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
