### PR TITLE
RWA-2246  Bump uk.gov.hmcts.java from 0.12.5 to 0.12.39

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.7'
   id 'org.owasp.dependencycheck' version '8.0.2'
-  id 'uk.gov.hmcts.java' version '0.12.5'
+  id 'uk.gov.hmcts.java' version '0.12.39'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.0'
   id 'io.freefair.lombok' version '5.3.3.3'


### PR DESCRIPTION
Bumps uk.gov.hmcts.java from 0.12.5 to 0.12.39.



You can trigger a rebase of this PR by commenting @dependabot rebase



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
